### PR TITLE
app.py:

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,7 +68,7 @@ class App:
 
     def _initialize_state(self):
         self.current_biomedical_concept = None
-        self.original_biomedical_concept = None
+        # self.original_biomedical_concept = None
         
         if verbose_:
             print("[Info] App.initialize_state: Initializing")
@@ -76,7 +76,7 @@ class App:
         print("\033[93m [Warning] App.initialize_state: No active repository found, creating new one \033[0m")
         print("\033[93m [Warning] App.initialize_state: Loading pre-existing repositories is not supported yet \033[0m")
         self.current_repository = Repository()
-        self.persistent_cdisc_repository = Repository()
+        # self.persistent_cdisc_repository = Repository()
         # self.persistent_cdisc_repository.business_therapeutic_areas = [TherapeuticArea(Code(code="USDM_PD01", code_system=Code.CodeSystem.CDISC,code_system_version="latest").decode("Latest retrieved repository items"))]
         json_categories = API.get_latest_biomedical_concept_categories()
         usdm_categories:list[USDM_Category] = list(map(USDM_Category.from_json, json_categories))
@@ -113,20 +113,29 @@ class App:
             return self.current_repository.business_therapeutic_areas
         
     def get_bcs_in_repository(self) -> list[USDM_BC]:
-        return self.current_repository.biomedical_concepts.values()
+        return list(self.current_repository.biomedical_concepts.values())
     
     def get_if_in_repository(self, id_:UUID)-> USDM_BC | None:
-        for temp_bc in self.get_bcs_in_repository():
-            # print(temp_bc)
-            if id_ == temp_bc.id_:
-                return temp_bc
+        
+        if self.exists_in_repository(id_):
+            return self.get_biomedical_concept_by_id(id_)
         return None
     
-    def get_from_cdisc_repository(self, request_id:UUID) -> USDM_BC:
-        for uuid, bc in self.persistent_cdisc_repository.biomedical_concepts.items():
-            if uuid == request_id:
-                return bc
-        raise ValueError(f"{BColors.FAIL} Request_id should be an UUID in the cache")
+    def exists_in_repository(self, id_:UUID) -> bool:
+        '''
+        Returns <code>True</code> if repository contains a BiomedicalConcept with the provided id,
+        otherwise returns <code>False</code>'''
+        return self.current_repository.contains_biomedical_concept(id_=id_)
+    
+    def remove_nth_bc_from_repository(self, selection:int) -> None:
+        self.current_repository.remove_nth_biomedical_concept(selection)
+
+
+    # def get_from_cdisc_repository(self, request_id:UUID) -> USDM_BC:
+    #     for uuid, bc in self.persistent_cdisc_repository.biomedical_concepts.items():
+    #         if uuid == request_id:
+    #             return bc
+    #     raise ValueError(f"{BColors.FAIL} Request_id should be an UUID in the cache")
         
     def apply_biomedical_concept_to_repository(self, bc_dao:dict) -> list[USDM_BC]:
         if bc_dao["label"] != self.current_biomedical_concept.label:
@@ -240,19 +249,19 @@ class App:
 
                     # RESPONSE CODES
                     if verbose_:
-                            if prop.response_codes is None:
-                                print(f"{BColors.WARNING}WARN|[App].apply_to_repository: prop.response_codes should never be none, it should be [] instead{BColors.ENDC}")
-                            elif len(prop.response_codes) > 0:
-                                print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: Attempting to resolve response codes{BColors.ENDC}")
-                                print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: Number of Response Codes found: {len(prop.response_codes)}{BColors.ENDC}")
-                            if len(dao_prop["response_codes"]) > 0:
-                                print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: first dao_rc is:{dao_prop["response_codes"][0]}{BColors.ENDC}")
-                            if len(prop.response_codes)> 0:
-                                print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: prop rc is:{prop.response_codes[0].label}{BColors.ENDC}")
-                            if len(dao_prop["response_codes"]) > len(prop.response_codes) :
-                                print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: amount of added notes is:{len(dao_prop["response_codes"][len(prop.notes):])}{BColors.ENDC}")
-                                print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: first adde note is:{dao_prop["response_codes"][len(prop.response_codes):][0]}{BColors.ENDC}")
-                                print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: Attempting to add additional {BColors.ENDC}")
+                        if prop.response_codes is None:
+                            print(f"{BColors.WARNING}WARN|[App].apply_to_repository: prop.response_codes should never be none, it should be [] instead{BColors.ENDC}")
+                        elif len(prop.response_codes) > 0:
+                            print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: Attempting to resolve response codes{BColors.ENDC}")
+                            print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: Number of Response Codes found: {len(prop.response_codes)}{BColors.ENDC}")
+                        if len(dao_prop["response_codes"]) > 0:
+                            print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: first dao_rc is:{dao_prop["response_codes"][0]}{BColors.ENDC}")
+                        if len(prop.response_codes)> 0:
+                            print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: prop rc is:{prop.response_codes[0].label}{BColors.ENDC}")
+                        if len(dao_prop["response_codes"]) > len(prop.response_codes) :
+                            print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: amount of added notes is:{len(dao_prop["response_codes"][len(prop.notes):])}{BColors.ENDC}")
+                            print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: first adde note is:{dao_prop["response_codes"][len(prop.response_codes):][0]}{BColors.ENDC}")
+                            print(f"{BColors.OKBLUE}INFO|[App].apply_to_repository: Attempting to add additional {BColors.ENDC}")
 
                     for rc in prop.response_codes:
                         for index, rc_dict in enumerate(dao_prop["response_codes"]):
@@ -332,7 +341,7 @@ class App:
 
     def set_categories(self, categories:list[USDM_Category]):
         self.categories = categories
-        self.persistent_cdisc_repository.bc_categories = categories
+        # self.persistent_cdisc_repository.bc_categories = categories
         # self.display.categories_container.set_categories([category.label for category in self.categories])
 
     #endregion
@@ -366,9 +375,9 @@ class App:
             biomedical_concepts_in_category = _bcs_in_category
         
         
-        for bc in biomedical_concepts_in_category:
-            if bc.id_ not in self.persistent_cdisc_repository.biomedical_concepts:
-                self.persistent_cdisc_repository.add_biomedical_concept(bc)
+        # for bc in biomedical_concepts_in_category:
+            # if bc.id_ not in self.persistent_cdisc_repository.biomedical_concepts:
+            #     self.persistent_cdisc_repository.add_biomedical_concept(bc)
         # self.persistent_cdisc_repository.biomedical_concepts.extend(self.biomedical_concepts_in_current_category)
        
         # self.biomedical_concepts_in_category = [USDM_BC(bc) for bc in API.get_biomedical_concepts_list(category.get_code(), all_codes)]
@@ -384,7 +393,7 @@ class App:
     
 
     #region Current Biomedical Concept
-    def select_bc(self, index:int):
+    def select_bc(self, index:int) -> None:
         if len(self.biomedical_concepts_in_current_category) > 0:
             selected_bc = self.biomedical_concepts_in_current_category[index]
             
@@ -404,6 +413,10 @@ class App:
             self.current_biomedical_concept = selected_bc
             return selected_bc
         return None
+    
+    def select_bc_from_repository(self, index:int) -> USDM_BC:
+        self.current_biomedical_concept = self.get_bcs_in_repository()[index]
+        return self.current_biomedical_concept
 
     def get_biomedical_concept_by_id(self, id_:UUID) -> USDM_BC | None:
         for bc in self.biomedical_concepts:

--- a/models/USDM/repository.py
+++ b/models/USDM/repository.py
@@ -52,6 +52,14 @@ class Repository:
     def set_biomedical_concept(self, bc_id:UUID, biomedical_concept:BiomedicalConcept):
         self.biomedical_concepts.update((bc_id, biomedical_concept))
 
+    def remove_nth_biomedical_concept(self, n:int) -> None:
+        # del self.biomedical_concepts[n]
+        for index, uuid in enumerate(self.biomedical_concepts):
+            if n == index:
+                self.biomedical_concepts.pop(uuid)
+                return
+        # self.biomedical_concepts.pop(key)
+
     def update_biomedical_concept(self, data:dict[UUID, dict[str,any]], id_:UUID):
         dirty = False
         
@@ -105,9 +113,11 @@ class Repository:
                                 code_system="CUSTOM",
                                 code_system_version=self.business_therapeutic_areas[0].code.code_system_version)]))
 
-        # old_bc.properties
-        # for new_prop in data[id_]["properties"]:
-        #     for old_prop in old_bc.properties:
-        #         # if new_prop
-        # compair property
-        # set property
+    def contains_biomedical_concept(self, id_:UUID=None, **kwargs) -> bool:
+        if id_ is not None:
+            for temp_bc in self.biomedical_concepts.values():
+                if id_ == temp_bc.id_:
+                    return True
+            return False
+        if len(kwargs) != 0 and id_ is not None:
+            raise NotImplementedError(f"Parameter with name {kwargs.keys()[0]} is not supported")

--- a/views/bc2usdm_window.py
+++ b/views/bc2usdm_window.py
@@ -79,10 +79,10 @@ class BC2USDM_Window():
         self.current_repository_container = RepositoryView(self, width=self.__data_column_width[3], x=self.__default_width-self.__data_column_width[3])
         self.root.mainloop()
 
-    def set_current_bc(self, bc):
+    def set_current_bc(self, bc, already_in_repository:bool=False):
         # Set current bc in main app
-        self.main_app.set_current_bc(bc)
-        self.current_bc_container.update_view(bc)
+        # self.main_app.set_current_bc(bc)
+        self.current_bc_container.update_view(bc, already_in_repository)
 
     # def update_current_bc(self, attr_name, value):
     #     self.main_app.update_current_bc(attr_name, value)
@@ -115,7 +115,14 @@ class BC2USDM_Window():
     def open_selected_category(self, selection):
         print(f"{BColors.OKGREEN}This is a stub to implement Category Selection{BColors.ENDC}")
         raise NotImplementedError()
+    
+    def open_selected_biomedical_concept(self, selection:int):
+    
+        bc = self.main_app.select_bc_from_repository(selection)
+        self.current_bc_container.update_view(bc, True)
 
+    def remove_nth_bc_from_repository(self, selection:int) -> None:
+        self.main_app.remove_nth_bc_from_repository(selection)
 
     def apply_bc_to_repository(self, bc_dict:dict):
         biomedical_concepts_in_repository = self.main_app.apply_biomedical_concept_to_repository(bc_dict)
@@ -123,3 +130,6 @@ class BC2USDM_Window():
         # Adding bcs no longer automatically adds the associated category, lines will be deleted soon
         # categories_in_repository = self.main_app.get_categories_in_repository()
         # self.current_repository_container.update_cat_list(categories_in_repository)
+
+    def set_editor_apply_btn_text(self, value:str="Add"):
+        self.current_bc_container.set_apply_bc_button_text(value)

--- a/views/current_biomedical_concept_view.py
+++ b/views/current_biomedical_concept_view.py
@@ -8,6 +8,9 @@ from views.property.properties_view import PropertiesView
 # and the UI code is a mess
 class CurrentBiomedicalConceptView(LabelFrame):
     DEFAULT_TITLE = "Current Biomedical Concept"
+    APPLY_TEXT = "Apply Changes"
+    ADD_TEXT = "Add"
+
     def __init__(self, parent,  width, x, **kwargs):
         self.parent = parent
         if "title" in kwargs.keys():
@@ -94,7 +97,7 @@ class CurrentBiomedicalConceptView(LabelFrame):
         bc_synonyms_entry.bind("<Return>", lambda event: self.synonym_add_cmd(bc_synonyms_entry.get()))
         # self.bc_synonyms_entry.bind("<Return>", self.synonym_add_cmd)
         
-        self.notes_frame = NotesFrame(self, notes="")
+        self.notes_frame = NotesFrame(self, notes=[])
         # self.notes_frame.pack(side=TOP, fill=BOTH, expand=FALSE)
         self.notes_frame.grid(row=(i:=i+1)-1, column=0, columnspan=2, sticky=NSEW, in_=self.master_frame)
         
@@ -105,7 +108,7 @@ class CurrentBiomedicalConceptView(LabelFrame):
         # Add add and remove btn
         btn_frame = Frame(self)
         btn_frame.pack(side=BOTTOM, fill=BOTH, expand=FALSE, padx=(5,5), pady=(0,5))
-        self.apply_txt_var = StringVar(value="Add")
+        self.apply_txt_var = StringVar(value=CurrentBiomedicalConceptView.ADD_TEXT)
         apply_btn = Button(btn_frame, textvariable=self.apply_txt_var, state="disabled")
         apply_btn["command"] = self.apply_changes_to_repository
         apply_btn.grid(row=0,column=1, sticky=EW)
@@ -145,6 +148,7 @@ class CurrentBiomedicalConceptView(LabelFrame):
         }
 
         _ = self.parent.apply_bc_to_repository(biomedical_concept_dict)
+        self.apply_txt_var.set(CurrentBiomedicalConceptView.APPLY_TEXT)
         
 
 
@@ -173,7 +177,7 @@ class CurrentBiomedicalConceptView(LabelFrame):
         self.bc_synonyms_listbox.config(height=label_height)
         self.bc_synonyms_entry_value.set("")
 
-    def update_view(self, bc, **kwargs):
+    def update_view(self, bc, already_in_repository:bool=False, **kwargs):
         # for kw, arg in kwargs:
         #     print(f"{kw}:{arg}")
 
@@ -194,12 +198,17 @@ class CurrentBiomedicalConceptView(LabelFrame):
 
         # Enable apply button
         self.apply_btn["state"] = "normal"
-        
+        if already_in_repository:
+            self.set_apply_bc_button_text(CurrentBiomedicalConceptView.APPLY_TEXT)
+        else:
+            self.set_apply_bc_button_text(CurrentBiomedicalConceptView.ADD_TEXT)
+        # self.set_editor_apply_btn_text("Add BC")
         # if bc._properties is not None:
         #     for prop in bc._properties:
         #         self.properties_frame.add_property(prop)
 
     
-
+    def set_apply_bc_button_text(self, value:str=APPLY_TEXT):
+        self.apply_txt_var.set(value)
         
 

--- a/views/current_category_view.py
+++ b/views/current_category_view.py
@@ -58,8 +58,8 @@ class CurrentCategoryView(LabelFrame):
             return
 
         temp_bc = self.parent.main_app.select_bc(selection[0])
-        
-        self.parent.set_current_bc(temp_bc)
+        already_in_repo:bool = self.parent.main_app.exists_in_repository(temp_bc.id_)
+        self.parent.set_current_bc(temp_bc, already_in_repo)
         
 
     def grab_focus(self):

--- a/views/notes_frame.py
+++ b/views/notes_frame.py
@@ -1,13 +1,14 @@
 from tkinter import LabelFrame, PanedWindow, StringVar, Text
 from tkinter.constants import *
 
+from models.USDM.comment_annotation import CommentAnnotation
 from utils.b_colors import BColors
 from views.scroll_frame import ScrollFrame
 
 
 class NotesFrame(LabelFrame):
     _line_height = 16 #pixels
-    def __init__(self, parent, lines=4, notes:list[str]=[""], min_textboxes=1, max_textboxes=3, *args, **kwargs):
+    def __init__(self, parent, lines=4, notes:list[CommentAnnotation]=[""], min_textboxes=1, max_textboxes=3, *args, **kwargs):
         self.lines=lines
         self.min_textboxes=min_textboxes
         self.max_textboxes=max_textboxes
@@ -25,7 +26,7 @@ class NotesFrame(LabelFrame):
         # Create a Textbox for each Note
         if notes is not None:
             for note_index, note in enumerate(notes):
-                self._add_text_box(note,4)
+                self._add_text_box(note.text,4)
 
         # when placing in the scrollframe, we pack scrollFrame itself (NOT the viewPort)
         self.scroll_frame.pack(side=TOP, fill=BOTH, expand=TRUE)

--- a/views/repository/repository_view.py
+++ b/views/repository/repository_view.py
@@ -1,6 +1,10 @@
-from tkinter import Button, Entry, Frame, IntVar, Label, LabelFrame, Listbox, Scrollbar, StringVar, Variable
-from tkinter.constants import *
-from uuid import uuid4 as guid
+from tkinter import Button, Entry, Frame, Label, LabelFrame, Listbox, Scrollbar, StringVar, Variable
+# from tkinter.constants import *
+from tkinter.constants import N, E, S, W # cardinals, sticky
+from tkinter.constants import NW, SE, SW # Anchors
+from tkinter.constants import VERTICAL # Allignment
+from tkinter.constants import X, BOTH # X/Y & Expand
+from tkinter.constants import TOP, LEFT, RIGHT # Side
 
 from utils.b_colors import BColors
 from models.USDM.biomedical_concept import BiomedicalConcept
@@ -18,8 +22,8 @@ class RepositoryView(LabelFrame):
 
     def __init__(self, parent, **kwargs):
         self.parent = parent
-        x = kwargs["x"]
-        del kwargs["x"]
+        x = kwargs[X]
+        del kwargs[X]
 
         if "title" in kwargs.keys():
             title = kwargs["title"]
@@ -33,10 +37,10 @@ class RepositoryView(LabelFrame):
         self.get_therapeutic_area = lambda index=0 : self.parent.main_app.get_therapeutic_areas(index)
         self.therapeutic_area_container = TherapeuticAreaView(self)
         
-        self.categories_container = RepositoryCategoryView(self)
+        # self.categories_container = RepositoryCategoryView(self)
         self.added_biomedical_concepts_container = RepositoryBiomedicalConceptsContainer(self)
         
-        super().place(anchor="nw",width=kwargs["width"], x=x, relheight=1)
+        super().place(anchor=NW,width=kwargs["width"], x=x, relheight=1)
 
         self.set_document_version = parent.main_app.set_document_version
         self.set_therapeutic_area_decode = parent.main_app.set_therapeutic_area_decode
@@ -44,12 +48,20 @@ class RepositoryView(LabelFrame):
     def update_bc_list(self, bcs:list[BiomedicalConcept]):
         self.added_biomedical_concepts_container.update_biomedical_concepts_list(bcs)
 
-    def update_cat_list(self, categories:list[BiomedicalConceptCategory]):
-        self.categories_container.update_category_list(categories)
+    # def update_cat_list(self, categories:list[BiomedicalConceptCategory]):
+    #     self.categories_container.update_category_list(categories)
 
     def open_selected_category(self, selection):
         self.parent.open_selected_category(selection)
 
+    def open_selected_biomedical_concept(self, selection):
+        self.parent.open_selected_biomedical_concept(selection)
+
+    def remove_bc_from_repository(self, selection:int) -> None:
+        self.parent.remove_nth_bc_from_repository(selection)
+
+    def set_editor_apply_btn_text(self, value:str="Add"):
+        self.parent.set_editor_apply_btn_text(value)
     
     
 
@@ -80,7 +92,7 @@ class TherapeuticAreaView(LabelFrame):
         Label(self, text="Code:").grid(row=_row, column=0, sticky=W)
         self.code_var = StringVar(value=this_ta.code.code)
         code_entry = Entry(self, justify=LEFT, textvariable=self.code_var, state="readonly")
-        code_entry.grid(row=(_row:=_row+1)-1, column=1, sticky=NSEW)
+        code_entry.grid(row=(_row:=_row+1)-1, column=1, sticky=(N,W,S,E))
 
         # Skipping UI element since this is a constant value
         #   - "codeSystem": "CUSTOM"                                                    -> Const Value
@@ -93,7 +105,7 @@ class TherapeuticAreaView(LabelFrame):
         Label(self, text="Version:").grid(row=_row, column=0, sticky=W)
         self.document_version_var = StringVar(value=this_ta.code.code_system_version)
         document_version_entry = Entry(self, justify=LEFT, textvariable=self.document_version_var)
-        document_version_entry.grid(column=1, row=(_row:=_row+1)-1, sticky=NSEW)
+        document_version_entry.grid(column=1, row=(_row:=_row+1)-1, sticky=(N,W,S,E))
         document_version_entry.bind("<FocusOut>",self.on_version_entry_focus_out)
         
         # Skipping ui element since this a contant value
@@ -107,7 +119,7 @@ class TherapeuticAreaView(LabelFrame):
         Label(self, text="Description").grid(row=_row, column=0, sticky=W)
         self.decode_var = StringVar(value=this_ta.code.decode)
         decode_entry = Entry(self, justify=LEFT, textvariable=self.decode_var)
-        decode_entry.grid(column=1, row=(_row:=_row+1)-1, sticky=NSEW)
+        decode_entry.grid(column=1, row=(_row:=_row+1)-1, sticky=(N,W,S,E))
         decode_entry.bind("<FocusOut>", self.on_decode_entry_focus_out)
         
         self.columnconfigure(index=1, weight=1)
@@ -155,7 +167,7 @@ class RepositoryCategoryView(LabelFrame):
             state="disabled" # Disabling listbox since category editing isn't supported yet
             )
         self.category_list.bind("<ButtonRelease>", self.category_list_select)
-        self.category_list.grid(column=0, row=0, sticky=NSEW)
+        self.category_list.grid(column=0, row=0, sticky=(N,W,S,E))
         category_scrollbar_y.config(command=self.category_list.yview)
         self.columnconfigure(0,weight=1)
         self.rowconfigure(0,weight=1)
@@ -212,6 +224,7 @@ class RepositoryBiomedicalConceptsContainer(LabelFrame):
     _btn_padding:int = 5
 
     def __init__(self, parent, **kwargs):
+        self.parent = parent
         if "title" in kwargs.keys():
             title = kwargs["title"]
             del kwargs["title"]
@@ -222,34 +235,63 @@ class RepositoryBiomedicalConceptsContainer(LabelFrame):
         bc_scrollbar_y = Scrollbar(self,orient=VERTICAL)
         bc_scrollbar_y.grid(column=1,row=0,sticky=(N,E,S))
         self.bc_list = Listbox(self, justify=LEFT, listvariable=self.bcs_var,
-                               yscrollcommand=bc_scrollbar_y.set)
-        self.bc_list.bind()
-        self.bc_list.grid(column=0, row=0, sticky=NSEW)
+                               yscrollcommand=bc_scrollbar_y.set, selectmode="single")
+        # self.bc_list.bind() # Using button to open instead
+        self.bc_list.grid(column=0, row=0, sticky=(N,W,S,E))
         bc_scrollbar_y.config(command=self.bc_list.yview)
         self.columnconfigure(0,weight=1)
         self.rowconfigure(0,weight=1)
 
         # Add container for buttons
         btn_container = self._add_buttons()
-        btn_container.config(bg="GREEN")
         btn_container.grid(column=0, row=1, columnspan=2, sticky=(W,S,E) ,padx=self._btn_padding)
         # self.rowconfigure(1,weight=0)
         
-
-        
-        super().pack(anchor=N, expand=TRUE, fill=BOTH, side=TOP)
+        super().pack(anchor=N, expand=True, fill=BOTH, side=TOP)
 
     def _add_buttons(self):
         btn_box = Frame(self)
         
-
         remove_button = Button(btn_box, text="Remove")
-        remove_button.pack(side=LEFT, anchor="sw", expand=True, fill=X)
+        remove_button.pack(side=LEFT, anchor=SW, expand=True, fill=X)
         open_button = Button(btn_box, text="Open")
-        open_button.pack(side=RIGHT, anchor="se", expand=True, fill=X)
-
-        return btn_box
+        open_button.pack(side=RIGHT, anchor=SE, expand=True, fill=X)
+        open_button.bind("<ButtonRelease-1>", self._open_btn_handler)
+        remove_button.bind("<ButtonRelease-1>", self._remove_btn_handler)
         
+        return btn_box
+    
+    
+    def _open_btn_handler(self, event):
+        if not len(self.bcs_var.get()) > 0:
+            return
+        
+        # print(self.bc_list.curselection())
+        if len(self.bc_list.curselection()):
+            selection:int = self.bc_list.curselection()[0]
+        else:
+            selection:int = 0
+        self.parent.open_selected_biomedical_concept(selection)
+
+    def _remove_btn_handler(self, event):
+        if not len(self.bcs_var.get()) > 0 or not self.bc_list.curselection():
+            print(f"{BColors.OKGREEN}No bcs to select or no bc selected, exiting.{BColors.ENDC}")
+            
+            return
+        
+        # print(self.bc_list.curselection())
+        if len(self.bc_list.curselection()):
+            selection:int = self.bc_list.curselection()[0]
+        else:
+            selection:int = 0
+        
+        print(f"{BColors.OKGREEN}index: {selection}{BColors.ENDC}")
+        self.parent.set_editor_apply_btn_text("Add")
+        self.parent.remove_bc_from_repository(selection)
+        temp_var =list(self.bcs_var.get()) #cast to list, since tuples are immutable
+        temp_var.pop(selection)
+        self.bcs_var.set(temp_var)
+
 
     
     def update_biomedical_concepts_list (self, bcs:list[BiomedicalConcept]):


### PR DESCRIPTION
App:
- removed all references to self.original_biomedial_concept and self.persistent_cdisc_repository, since persistence isn't planned in this milestone yet
- Fixed: get_bcs_in_repository now returns a list of bcs, instead of a dict mapping.
- added exists_in_repository to check if a bc is already in the repo, currently accepted params: uuid
- added remove_nth_bc_from_repository as part of the remove button feature.
- added select_bc_from_repository, accepted params: index:int, returns: BiomedicalConcept

Repository:
- added remove_nth_biomedical_concept(n:int) as part of the added remove button feature
- added contains_biomedical_concept(id_:uuid) -> bool, as part of the added open button feature.

bc2usdm_window:
- Added open_selected_biomedical_concept(selection:int) as part of the Open button feature
- Added set_editor_apply_btn_text, to change the text on the apply/add button depending on whether the bc in is the repo already

CurrentBiomedicalConceptView:
- update_view method now takes a boolean parameter specifying if the bc is already in the repository to set the apply/add button text
- added method to set the text on the apply/add btn
- Added contants for apply and add label of the apply/add btn

NotesFrame:
Fixed: The notes frame as part of the properties frame now correctly shows the property's notes, instead of the object reference.

repository_view.py:
- Made tkinter.constants import more consistent and explicit (instead of using wildcard) Repository_View:
- Commented out categories container and update_cat_list, since managing categories is currently not supported in this version
- Added handler for the open button in the repository's bc list
- Added handler for the removebutton in the repository's bc list

Closes #25, closes #30 